### PR TITLE
Add a retry around Pkg.build

### DIFF
--- a/action.yml
+++ b/action.yml
@@ -31,5 +31,5 @@ runs:
       # packages via `Pkg.test`.
       JULIA_PKG_SERVER: ""
 
-  - run: julia --color=yes --project=${{ inputs.project }} -e 'using Pkg; if VERSION >= v"1.1.0-rc1"; Pkg.build(verbose=true); else Pkg.build(); end'
+  - run: julia --color=yes --project=${{ inputs.project }} -e 'using Pkg; retry_build = retry(Pkg.build); if VERSION >= v"1.1.0-rc1"; retry_build(verbose=true); else retry_build(); end'
     shell: bash


### PR DESCRIPTION
Sometimes GitHub returns a 5xx error when downloading artifacts, so a retry when calling `Pkg.build` is helpful to not fail the build for transient errors.
